### PR TITLE
Update taggable-searcher version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "async": "^2.0.0-rc.3",
     "aws-lambda-helper": "^2.18.0",
     "env2": "^2.0.7",
-    "taggable-searcher": "^5.0.1",
+    "taggable-searcher": "^6.0.0",
     "tv4": "^1.2.7"
   },
   "semistandard": {


### PR DESCRIPTION
Fixes a bug where the correct environment is not used to configure the S3 locations in `taggable-searcher#store`