### PR TITLE
Log the number of tiles actually returned by the content handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ exports.handler = function (event, context, callback) {
     // Fetch the content for the tile ids.
     contentHandler.get(tiles, (_, data) => {
       // Note that contentHandler will never throw an error.
-      aws.log.trace({ message: message, tiles: tiles.length }, 'Handle Save');
+      aws.log.trace({ message: message, tiles: data.length, expected: tiles.length }, 'Handle Save');
       saveHandler.save(message.context.connectionId, message.context.searchId, message.context.userId, data, (err, result) => {
         if (err) {
           aws.log.error(err, 'Unable handle save');


### PR DESCRIPTION
It looks possible that the content handler is not correctly processing all of the tiles when the number to process is large. To check this, include a log for the number of tiles returned from the content handler function as well as the input length.