### PR TITLE
Log the results that are sent to the client

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ exports.handler = function (event, context, callback) {
           aws.log.error(err, 'Unable handle save');
           return callback(err);
         }
-        aws.log.trace({ results: { expected: result.length, actual: result.length } }, 'Processed tiles');
+        aws.log.trace('Processed tiles');
         return callback(null, `Processed ${data.length} tiles`);
       });
     });

--- a/lib/saveHandler.js
+++ b/lib/saveHandler.js
@@ -27,7 +27,7 @@ function save (sessionId, searchId, userId, tiles, callback) {
     if (err) {
       awsLambdaHelper.log.error(err, 'Error when pushing to client');
     }
-    awsLambdaHelper.log.trace({ toClient: data }, 'Pushing to client');
+    awsLambdaHelper.log.trace({ toClient: data, results: params.items }, 'Pushing to client');
     return callback(err, data);
   });
 }


### PR DESCRIPTION
Also remove a slightly redundant trace log, since the result from the saveHandler callback is not an array, both (identical) properties are undefined.